### PR TITLE
Add Docker Compose setup for shared model storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # AI Image Generation Containers
 
 This repository contains various containerized applications designed for AI-based image generation. These containers are optimized for use with NVIDIA GPUs, enabling efficient and high-performance image generation workflows.
+
+## Docker Compose Instructions
+
+To run the AI image generation containers with shared model storage, the `docker-compose.yml` file can be used. The setup allows both containers to share the same models mount point for efficient disk space usage.Use the command `docker-compose up` to start the services.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  comfyui:
+    image: ghcr.io/burritocatai/comfyui:0.3.10-cuda-12.4
+    container_name: comfyui
+    hostname: "comfyui"
+    ports:
+      - "8082:8082/tcp"
+    volumes:
+      - "./comfyui_models:/comfyui/ComfyUI/models"
+      - "./comfyui_nodes:/comfyui/ComfyUI/custom_nodes"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+
+  sdnext:
+    container_name: sdnext
+    hostname: "sdnext"
+    image: ghcr.io/burritocatai/sdnext:cuda-12.4
+    ports:
+      - "7860:7860/tcp"
+    volumes:
+      - "./comfyui_models:/sdnext/automatic/models"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]


### PR DESCRIPTION
Introduced a `docker-compose.yml` file to streamline service setup for AI image generation containers. Both containers now share a common model storage path, optimizing disk space usage and simplifying deployment. Updated the README with usage instructions for Docker Compose.